### PR TITLE
doc: update descriptions and add French translation 

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -14,5 +14,4 @@ It is the server component for the [FindMyDevice](https://gitlab.com/Nulide/find
 
 ### Integration with YunoHost
 
-- This package installs the Django-based FMD Server.
 - You need to install the FindMyDevice app on your Android device and configure it to point to your server URL.

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,14 +1,18 @@
-Find My Device Server implemented in Python using Django.
-Usable for the Andorid App [**FindMyDevice**](https://gitlab.com/Nulide/findmydevice/) by [Nnulide](https://nulide.de/):
+Find My Device (FMD) Server allows you to track and control your Android device remotely.
 
-[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get FindMyDevice on F-Droid" height="80">](https://f-droid.org/packages/de.nulide.findmydevice/)
+It is the server component for the [FindMyDevice](https://gitlab.com/Nulide/findmydevice/) Android app (available on [F-Droid](https://f-droid.org/packages/de.nulide.findmydevice/)).
 
-[![pytest](https://github.com/YunoHost-Apps/django-fmd_ynh/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/YunoHost-Apps/django-fmd_ynh/actions/workflows/pytest.yml) [![YunoHost apps package linter](https://github.com/YunoHost-Apps/django-fmd_ynh/actions/workflows/package_linter.yml/badge.svg)](https://github.com/YunoHost-Apps/django-fmd_ynh/actions/workflows/package_linter.yml) [![Coverage Status on codecov.io](https://codecov.io/gh/YunoHost-Apps/django-fmd_ynh/branch/master/graph/badge.svg)](https://codecov.io/gh/YunoHost-Apps/django-fmd_ynh)
+### Features
 
-[![django-fmd @ PyPi](https://img.shields.io/pypi/v/django-fmd?label=django-fmd%20%40%20PyPi)](https://pypi.org/project/django-fmd/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/django-fmd)](https://gitlab.com/jedie/django-find-my-device/-/blob/main/pyproject.toml)
-[![License GPL V3+](https://img.shields.io/pypi/l/django-fmd)](https://gitlab.com/jedie/django-find-my-device/-/blob/main/LICENSE)
+- **Locate your device**: View your device's location on a map.
+- **Remote control**: Send commands to your device from the web interface.
+  - Ring the device.
+  - Lock the device.
+  - Take pictures with the front/back camera to see surroundings.
+  - Wipe/Reset the device (factory reset).
+- **View data**: Access photos taken by the device and location history.
 
-Pull requests welcome ;)
+### Integration with YunoHost
 
-This package for YunoHost used [django-yunohost-integration](https://github.com/YunoHost-Apps/django_yunohost_integration)
+- This package installs the Django-based FMD Server.
+- You need to install the FindMyDevice app on your Android device and configure it to point to your server URL.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,0 +1,18 @@
+Le serveur Find My Device (FMD) vous permet de localiser et contrôler votre appareil Android à distance.
+
+C'est la composante serveur pour l'application Android [FindMyDevice](https://gitlab.com/Nulide/findmydevice/) (disponible sur [F-Droid](https://f-droid.org/packages/de.nulide.findmydevice/)).
+
+### Fonctionnalités
+
+- **Localiser votre appareil** : Voir la position de votre appareil sur une carte.
+- **Contrôle à distance** : Envoyer des commandes à votre appareil depuis l'interface web.
+  - Faire sonner l'appareil.
+  - Verrouiller l'appareil.
+  - Prendre des photos avec la caméra avant/arrière pour voir les environs.
+  - Effacer/Réinitialiser l'appareil (retour aux paramètres d'usine).
+- **Visualiser les données** : Accéder aux photos prises par l'appareil et à l'historique de localisation.
+
+### Intégration avec YunoHost
+
+- Vous devez installer l'application FindMyDevice sur votre appareil Android et la configurer pour pointer vers l'URL de votre serveur.
+

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@ packaging_format = 2
 id = "django-fmd"
 name = "Find My Device"
 description.en = "Track, wipe and issue other commands to your device when it's lost"
+description.fr = "Localisez, réinitialisez et envoyez d'autres commandes à votre appareil en cas de perte"
 
 version = "0.9.1~ynh2"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -51,26 +51,31 @@ ram.runtime = "50M" # **estimate** minimum ram requirement. e.g. 50M, 400M, 1G, 
 
     [install.update_python] # __UPDATE_PYTHON__
     ask.en = "How to update Python? 'setup' will use redistributable Python builts (fast), 'install' will compile Python from source (slow)."
+    ask.fr = "Comment mettre à jour Python ? 'setup' utilisera des versions redistribuables de Python (rapide), 'install' compilera Python depuis les sources (lent)."
     type = "select"
     choices = ["INSTALL", "SETUP"]
     default = "SETUP"
 
     [install.default_from_email] # __DEFAULT_FROM_EMAIL__
     ask.en = "Default email address to use for various automated emails."
+    ask.fr = "Adresse e-mail par défaut pour les e-mails automatiques."
     type = "email"
     example = "admin@example.com"
 
     [install.admin_email] # __ADMIN_EMAIL__
-    ask.en = "EMail address for error emails."
+    ask.en = "Email address for error emails."
+    ask.fr = "Adresse e-mail pour les e-mails d'erreurs."
     type = "email"
     example = "admin@example.com"
 
     [install.debug_enabled] # __DEBUG_ENABLED__ will be set to "0" or "1" string
-    ask.en = "Should be never enabled in production!"
+    ask.en = "Debug mode (should never be enabled in production !)"
+    ask.fr = "Mode débogage (ne devrait jamais être activé en production !)"
     type = "boolean"
 
     [install.log_level] # __LOG_LEVEL__
     ask.en = "Logging level"
+    ask.fr = "Niveau de journalisation"
     type = "select"
     choices.debug = "DEBUG"
     choices.info = "INFO"


### PR DESCRIPTION
## Problem

- The application package was missing French localization for the description and documentation.
- The `manifest.toml` install questions were missing French translations.

## Solution

- Updated `doc/DESCRIPTION.md` to provide a more detailed and structured description of the app features
- Added `doc/DESCRIPTION_fr.md` with the French translation of the detailed description.
- Added `description.fr` to `manifest.toml` for the short French description.
- Added French translations (`ask.fr`) for installation questions in `manifest.toml`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)